### PR TITLE
Issue #2: Update private.ps1 to match secret name case between Read-Config() and Set-SmartsheetAPIKey()

### DIFF
--- a/private/private.ps1
+++ b/private/private.ps1
@@ -8,7 +8,7 @@ function Read-Config () {
     $ConfigPath = "$home/.smartsheet/config.json"
     $config = Get-Content -Raw -Path $ConfigPath | ConvertFrom-Json
     if ($Config.APIKey -eq 'secure') {
-        $Secret = Get-Secret -Name 'Smartsheet' -AsPlainText | ConvertFrom-Json
+        $Secret = Get-Secret -Name 'SmartSheet' -AsPlainText | ConvertFrom-Json
         $Config.APIKey = $Secret.APIKey
     }
     return $config


### PR DESCRIPTION
Issue #2: match Read-Config() secret name case with Set-SmartsheetAPIKey() secret name case for vaults that are case sensitive.